### PR TITLE
Improve CDDL schema using extension point syntax

### DIFF
--- a/draft-laari-asdf-relations.md
+++ b/draft-laari-asdf-relations.md
@@ -264,19 +264,33 @@ This document has no IANA actions.
 
 # Appendix A. Formal Syntax of sdf-relation
 
-<sourcecode>
-sdfRelation = ( sdfRelation: {
+~~~ cddl
+$$SDF-EXTENSION-THING //= sdf-relation
+$$SDF-EXTENSION-OBJECT //= sdf-relation
+$$SDF-EXTENSION-ACTION //= sdf-relation
+$$SDF-EXTENSION-EVENT //= sdf-relation
+$$SDF-EXTENSION-DATA //= sdf-relation
+
+sdf-relation = ( 
+  sdfRelation: named<relation-entries>
+)
+
+relation-entries = {
   ? relType: global
   ? target: global
   ? description: text
   ? label: text
   ? property: { * text => text }
   ? $comment: text
-})
+}
+
+; Shortcut for a map that gives names to instances of X
+; (has keys of type text and values of type X)
+named<X> = { * text => X }
 
 ; from SDF CDDL
 global = text .regexp ".*[:#].*" ; rough CURIE or JSON Pointer syntax
-</sourcecode>
+~~~
 
 --- back
 


### PR DESCRIPTION
Looking at the CDDL schema a bit more closely, I've noticed that the old schema might have slightly off in comparison to what was intended with it. This PR therefore proposes a restructuring, while also explicitly defining `sdfRelation` as an extension using a couple of the predefined sockets from the main SDF specification.

I am currently not exactly sure whether I got everything right, but this PR should be enough as a first basis for further refinements.